### PR TITLE
Cleanup Task Scripts

### DIFF
--- a/esm_master/cli.py
+++ b/esm_master/cli.py
@@ -39,6 +39,10 @@ def main():
     parser.add_argument(
         "--version", action="version", version="%(prog)s 3.0 (Oct 01, 2019)"
     )
+    parser.add_argument(
+            "--keep-task-script", "-k", dest="keep", action="store_true", default=False,
+            help="Keep shell script generated to perform compilation/configuration jobs"
+            )
     parsed_args = vars(parser.parse_args())
 
     check = False
@@ -52,6 +56,8 @@ def main():
             check = parsed_args["check"]
         if "verbose" in parsed_args:
             verbose = parsed_args["verbose"]
+        if "keep" in parsed_args:
+            keep = parsed_args["keep"]
 
     if not target:
         target = ""
@@ -70,7 +76,7 @@ def main():
     complete_config = complete_setup.config
 
     env = esm_environment.environment_infos("compiletime", complete_config)
-    
+
     setups2models.replace_last_vars(env)
 
     user_task = task(target, setups2models, vcs, main_infos)
@@ -80,13 +86,17 @@ def main():
     user_task.output_steps()
 
     if check:
-        sys.exit(0)
+        return 0
     user_task.validate()
     env.write_dummy_script()
 
     user_task.execute(env)
     database = database_actions.database_entry(user_task.todo, user_task.package.raw_name, ESM_MASTER_DIR)
     database.connection.close()
+
+    if not keep:
+        env.cleanup_dummy_script()
+        user_task.cleanup_script()
 
     return 0
 

--- a/esm_master/esm_master.py
+++ b/esm_master/esm_master.py
@@ -257,19 +257,19 @@ class software_package:
         elif self.kind == "setups":
             couplings = setup_info.get_config_entry(self, "couplings")
             if couplings:
-                for coupling in couplings: 
+                for coupling in couplings:
                     changes = []
                     if "coupling_changes" in config["couplings"][coupling]:
-                        these_changes = config["couplings"][coupling]["coupling_changes"]       
+                        these_changes = config["couplings"][coupling]["coupling_changes"]
                         if these_changes:
                             changes = changes + these_changes
         return changes
-        
+
 
     def get_subpackages(self, setup_info, vcs, general):
         subpackages = []
         config = setup_info.config
-       
+
 
         if self.kind == "setups":
             couplings = setup_info.get_config_entry(self, "couplings")
@@ -277,7 +277,7 @@ class software_package:
                 for coupling in couplings:
                     newpackage = software_package(coupling, setup_info, vcs, general)
                     subpackages += newpackage.get_subpackages(setup_info, vcs, general)
-                            
+
         if self.kind == "couplings":
             components = setup_info.get_config_entry(self, "components")
             if components:
@@ -293,7 +293,7 @@ class software_package:
                         subpackages.append(newpackage)
 
         elif self.kind == "components":
-            requirements = setup_info.get_config_entry(self, "requires") 
+            requirements = setup_info.get_config_entry(self, "requires")
             if requirements:
                 for component in requirements:
                     found = False
@@ -329,7 +329,7 @@ class software_package:
         #                        software_package(component, setup_info, vcs, general)
         #                    )
         #elif self.kind == "components":
-        #    requirements = setup_info.get_config_entry(self, "requires") 
+        #    requirements = setup_info.get_config_entry(self, "requires")
         ##    if requirements:
         #        for requirement in requirements:
         #            found = False
@@ -422,7 +422,7 @@ class software_package:
             print ("    Coupling Changes:")
             for todo in self.coupling_changes:
                 print ("        ", todo)
-    
+
 
 
 
@@ -470,7 +470,7 @@ class task:
         self.subtasks=self.get_subtasks(setup_info, vcs, general)
         self.only_subtask=self.validate_only_subtask()
         self.ordered_tasks=self.order_subtasks(setup_info, vcs, general)
-   
+
         self.will_download = self.check_if_download_task(setup_info)
         self.folders_after_download=self.download_folders()
         self.binaries_after_compile=self.compile_binaries()
@@ -562,7 +562,7 @@ class task:
             todos = setup_info.meta_command_order[self.todo]
         else:
             todos = [self.todo]
-        
+
         ordered_tasks = []
         for todo in todos:
             for task in subtasks:
@@ -650,7 +650,7 @@ class task:
                 if task.todo in ["conf", "comp"]:
                     #if self.package.kind in ["setups", "couplings"]:
                     if not task.package.kind in ["setups", "couplings"]:
-                        if self.package.subpackages: 
+                        if self.package.subpackages:
                             real_command_list.append("cp ../"+task.raw_name+"_script.sh .")
                         real_command_list.append("./"+task.raw_name+"_script.sh")
                 else:
@@ -677,7 +677,15 @@ class task:
             real_command_list.append("cd ..")
 
         return real_command_list, command_list
-            
+
+    def cleanup_script(self):
+        for task in self.ordered_tasks:
+            if task.todo in ["conf", "comp"]:
+                try:
+                    os.remove("./"+task.raw_name+"_script.sh")
+                except OSError:
+                    print("No file to remove for ", task.raw_name)
+
 
     def check_if_target(self, setup_info):
         if not setup_info.has_target2(self.package, self.todo):
@@ -808,7 +816,7 @@ class setup_and_model_infos:
         for model in self.config["components"]:
             version = self.config["components"][model]["version"]
             model_dir = self.config["components"][model]["model_dir"]
-            user_config.update({model: 
+            user_config.update({model:
                                     {
                                      "model": model,
                                      "version": version,
@@ -873,7 +881,7 @@ class setup_and_model_infos:
             sep = ""
             if toplevel == "":
                 if "requires" in self.config[kind][model]:
-                    toplevel = model + "-" + version 
+                    toplevel = model + "-" + version
                     sep = "/"
             else:
                 sep = "/"
@@ -887,7 +895,7 @@ class setup_and_model_infos:
                 for requirement in self.config[kind][model]["requires"]:
                     reduced_config = self.append_to_conf(requirement, reduced_config, toplevel)
 
-        return reduced_config 
+        return reduced_config
 
 
     #def reduce(self, target, env):


### PR DESCRIPTION
Allows to cleanup the task scripts when compiling, configuring, etc. This is the new default behavior. To keep the scripts, you can use the `-k` option.