### PR TITLE
Hotfix/standalone cp binaries

### DIFF
--- a/esm_master/__init__.py
+++ b/esm_master/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "4.1.1"
+__version__ = "4.1.2"
 
 from . import database

--- a/esm_master/esm_master.py
+++ b/esm_master/esm_master.py
@@ -755,7 +755,12 @@ class task:
                             # PG: Only copy if source and dest aren't the same!
                             # (Prevents cp: ‘/temp/test.txt’ and
                             # ‘/temp/test/test.txt’ are the same file)
-                            if task.package.destination != toplevel:
+                            toplevel_bin_path = (
+                                toplevel + "/"
+                                + task.package.bin_type + "/"
+                                + binfile.split("/")[-1]
+                            )
+                            if not os.path.exists(toplevel_bin_path):
                                 command_list.append(
                                     "cp "
                                     + task.package.destination

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.1
+current_version = 4.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_master",
-    version="4.1.1",
+    version="4.1.2",
     zip_safe=False,
 )


### PR DESCRIPTION
Fixed a bug for which standalone component compilation will not copy the binaries to the toplevel bin folder