### PR TITLE
Hotfix/recomp standalone bin

### DIFF
--- a/esm_master/__init__.py
+++ b/esm_master/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 
 from . import database

--- a/esm_master/task.py
+++ b/esm_master/task.py
@@ -292,7 +292,7 @@ class Task:
                             # MA: If there are already commands that will clean the
                             # bin folder, the following `if` is required to be true
                             clean_command_list = [
-                                "mkdir -p " + toplevel + "/" + task.package.bin_type
+                                "rm -f " + toplevel + "/" + task.package.bin_type
                             ]
                             clean_command = any(cc in command_list for cc in clean_command_list)
                             if not os.path.exists(toplevel_bin_path) or clean_command:

--- a/esm_master/task.py
+++ b/esm_master/task.py
@@ -292,7 +292,7 @@ class Task:
                             # MA: If there are already commands that will clean the
                             # bin folder, the following `if` is required to be true
                             clean_command_list = [
-                                "rm -f " + toplevel + "/" + task.package.bin_type
+                                "rm -f " + toplevel_bin_path
                             ]
                             clean_command = any(cc in command_list for cc in clean_command_list)
                             if not os.path.exists(toplevel_bin_path) or clean_command:

--- a/esm_master/task.py
+++ b/esm_master/task.py
@@ -289,7 +289,13 @@ class Task:
                                 + task.package.bin_type + "/"
                                 + binfile.split("/")[-1]
                             )
-                            if not os.path.exists(toplevel_bin_path):
+                            # MA: If there are already commands that will clean the
+                            # bin folder, the following `if` is required to be true
+                            clean_command_list = [
+                                "mkdir -p " + toplevel + "/" + task.package.bin_type
+                            ]
+                            clean_command = any(cc in command_list for cc in clean_command_list)
+                            if not os.path.exists(toplevel_bin_path) or clean_command:
                                 command_list.append(
                                     "cp "
                                     + task.package.destination

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.1
+current_version = 4.2.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_master",
-    version="4.2.1",
+    version="4.2.2",
     zip_safe=False,
 )


### PR DESCRIPTION
This solves a problem in issue esm-tools/esm_tools#77.

Recompilation of ECHAM was successful, but if a binary existed in the bin folder (i.e. `echam-6.3.04p1/bin/echam6`), the following lines will find it out and avoid entering in the `if` that builds the command for copying the binary from the `src` to the `bin` folder:

```
                            toplevel_bin_path = (
                                toplevel + "/"
                                + task.package.bin_type + "/"
                                + binfile.split("/")[-1]
                            )
                            if not os.path.exists(toplevel_bin_path):
                                command_list.append(
                                    "cp "
                                    + task.package.destination
                                    + "/"
                                    + binfile
                                    + " "
                                    + toplevel
                                    + "/"
                                    + task.package.bin_type
                                )
                                real_command_list.append(
                                    "cp "
                                    + task.package.destination
                                    + "/"
                                    + binfile
                                    + " "
                                    + toplevel
                                    + "/"
                                    + task.package.bin_type
                                )
```

This was solved by checking if there is already a `rm -f ` command in the `command_list` and, if that exists, it means that the `toplevel_bin_path` file is going to be deleted and and the `if` that copies the binary is allowed.