### PR TITLE
Feature/build dkrz icon 2.6.2 rc

### DIFF
--- a/esm_master/compile_info.py
+++ b/esm_master/compile_info.py
@@ -54,6 +54,7 @@ def combine_components_yaml():
 
     relevant_entries = [
             "git-repository",
+            "repo_options", # kh 11.09.20 support git options like --recursive
             "branch",
             "tag",
             "comp_command",

--- a/esm_master/general_stuff.py
+++ b/esm_master/general_stuff.py
@@ -233,6 +233,15 @@ class version_control_infos:
                 return None
             try:
                 raw_command = self.config[package.repo_type][todo + "_command"]
+
+# kh 11.09.20 support git options like --recursive
+                if package.repo_options:
+                    define_options = self.config[package.repo_type]["define_options"]
+                    raw_command = raw_command.replace("${define_options}", define_options)
+                    raw_command = raw_command.replace("${repo_options}", package.repo_options)
+                else:
+                    raw_command = raw_command.replace("${define_options} ", "")
+                    raw_command = raw_command.replace("${repo_options}", "")  # kh 11.09.20 should not really be necessary
                 if package.branch:
                     define_branch = self.config[package.repo_type]["define_branch"]
                     raw_command = raw_command.replace("${define_branch}", define_branch)

--- a/esm_master/software_package.py
+++ b/esm_master/software_package.py
@@ -38,7 +38,9 @@ class software_package:
             self.fill_in_infos(setup_info, vcs, general)
         else:
             self.targets = self.subpackages = None
-            self.repo_type = self.repo = self.branch = None
+
+# kh 11.09.20 support git options like --recursive
+            self.repo_type = self.repo = self.branch = self.repo_options = None
             self.bin_type = None
             self.bin_names = [None]
             self.command_list = None
@@ -50,7 +52,9 @@ class software_package:
         self.targets = self.get_targets(setup_info, vcs)
         self.subpackages = self.get_subpackages(setup_info, vcs, general)
         self.complete_targets(setup_info)
-        self.repo_type, self.repo, self.branch = self.get_repo_info(setup_info, vcs)
+
+# kh 11.09.20 support git options like --recursive
+        self.repo_type, self.repo, self.branch, self.repo_options = self.get_repo_info(setup_info, vcs)
         self.destination = setup_info.get_config_entry(self, "destination")
         if not self.destination:
             self.destination = self.raw_name
@@ -58,6 +62,7 @@ class software_package:
         self.coupling_changes = self.get_coupling_changes(setup_info)
         self.repo = replace_var(self.repo, self.model + ".version", self.version)
         self.branch = replace_var(self.branch, self.model + ".version", self.version)
+        self.repo_options = replace_var(self.repo_options, self.model + ".version", self.version)
 
         self.bin_type, self.bin_names = self.get_comp_type(setup_info)
         self.command_list = self.get_command_list(setup_info, vcs, general)
@@ -206,7 +211,11 @@ class software_package:
                 repo_type = check_repo
                 break
         branch = setup_info.get_config_entry(self, "branch")
-        return repo_type, repo, branch
+
+# kh 11.09.20 support git options like --recursive
+        repo_options = setup_info.get_config_entry(self, "repo_options")
+
+        return repo_type, repo, branch, repo_options
 
     def get_command_list(self, setup_info, vcs, general):
         command_list = {}
@@ -248,6 +257,10 @@ class software_package:
                 self.repo,
                 ", branch: ",
                 self.branch,
+
+# kh 11.09.20 support git options like --recursive
+                ", repo_options: ",
+                self.repo_options,
             )
         if self.bin_type:
             print("    Bin_type: ", self.bin_type, ", bin_names: ", self.bin_names)


### PR DESCRIPTION
build support for DKRZ ICON version 2.6.2-rc added for mistral (using openmpi) and ollie (using intel mpi)