### PR TITLE
added clone_destination required for uncoupled NEMO setups

### DIFF
--- a/esm_master/compile_info.py
+++ b/esm_master/compile_info.py
@@ -66,6 +66,7 @@ def combine_components_yaml():
             "install_bins",
             "install_libs",
             "destination",
+            "clone_destination",
             "archfile",
             "use_oasis"
             ]

--- a/esm_master/general_stuff.py
+++ b/esm_master/general_stuff.py
@@ -264,7 +264,9 @@ class version_control_infos:
                 )
             raw_command = raw_command.replace("${repository}", repo)
             if todo == "get":
-                if package.destination:
+                if package.clone_destination:
+                    raw_command = raw_command + " " + package.clone_destination
+                elif package.destination:
                     raw_command = raw_command + " " + package.destination
                 else:
                     raw_command = raw_command + " " + package.raw_name

--- a/esm_master/software_package.py
+++ b/esm_master/software_package.py
@@ -43,6 +43,7 @@ class software_package:
             self.bin_names = [None]
             self.command_list = None
             self.destination = None
+            self.clone_destination = None
             self.coupling_changes = None
 
     def fill_in_infos(self, setup_info, vcs, general):
@@ -52,6 +53,7 @@ class software_package:
         self.complete_targets(setup_info)
         self.repo_type, self.repo, self.branch = self.get_repo_info(setup_info, vcs)
         self.destination = setup_info.get_config_entry(self, "destination")
+        self.clone_destination = setup_info.get_config_entry(self, "clone_destination")
         if not self.destination:
             self.destination = self.raw_name
 


### PR DESCRIPTION
To get/compile NEMO standalone with esm_master we need to set the target directory to where a NEMO configuration is cloned to. In the current setup `esm_master` assumes that "destination" entry is used as both as the target directory for a "git clone ... AND the top level directory. 
I introduced `clone_destination` (better names suggestions are highly appreciated) as an extra flag to allow setting the git clone destination differently than the top level directory.
Maybe this problem doesn't exist if NEMO standalone is integrated differently in the tools, but I currently don't know how to do that better.