### PR TITLE
modify build vars through coupling files

### DIFF
--- a/esm_master/compile_info.py
+++ b/esm_master/compile_info.py
@@ -441,7 +441,7 @@ class setup_and_model_infos:
         ``reduced_config``. It only adds these variables if they already exist in
         ``reduced_config``. This is done this way to limit the variables that can be
         defined in the ``coupled_component_changes`` to only the ones in
-        ``relevant_entries`` (the onces necessary for compilation). Remember, so far
+        ``relevant_entries`` (the ones necessary for compilation). Remember, so far
         the ``couplings`` files are only build-related, `runtime` configurations should
         go into the ``setups`` files.
 


### PR DESCRIPTION
While trying to get `MPIESM` to work I realized that the following lines in the `mpiesm.yaml` were not making it into the `conf_command` of `MPIOM`:

**mpiesm.yaml**
```
general:
        [ ... ]
mpiom:
        conf_command: conf_command: ./configure --prefix=${model_dir} --disable-mh-file --with-coupler=oasis3-mct --enable-HAMOCC --with-mpi=intelmpi
```
Instead, the `conf_command` from `mpiom.yaml` was used, which has no `--with-coupler=oasis3-mct`. Therefore, a simulation with MPIESM was not possible as it was compiling MPIOM as standalone.

The problem was that **no variables from the component sections of the setups are used by `esm_master`**, but this is meant to be like that by design. The solution here allows you to introduce build-changes for coupled setups through the `coupling` files, instead.

Now it is possible to define variables inside the coupling files, under a dictionary `coupled_component_changes`, so that changes in the building variables can be performed.

This is how the coupling file `mpiom-1.6.3p2+echam-6.3.05p2` for MPIESM looks like now:
```
components:
- echam-6.3.05p2
- mpiom-1.6.3p2
- oasis3mct-2.8
coupling_changes:
- sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2/CMakeLists.txt
- sed -i '/(OASIS3MCTROOT)/s:include:oasis/build/lib/psmile:g' mpiom-1.6.3p2/configure
coupled_component_changes:
    mpiom:
        conf_command: ./configure --prefix=${model_dir} --disable-mh-file --with-coupler=oasis3-mct --enable-HAMOCC
```

**Note**: It only adds these variables if they already exist in `reduced_config`. This is done this way to limit the variables that can be defined in the `coupled_component_changes` to only the ones in `relevant_entries` (the ones necessary for compilation). Remember, so far the `couplings` files are only build-related, `runtime` configurations should go into the `setups` files.