### PR TITLE
Verbose control

### DIFF
--- a/esm_master/__init__.py
+++ b/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.6"
+__version__ = "5.0.7"
 
 
 from . import database

--- a/esm_master/esm_master.py
+++ b/esm_master/esm_master.py
@@ -2,8 +2,12 @@
 # import fileinput, os, sys, getopt
 
 import sys
+import os
+import yaml
 
 from . import database_actions
+
+# deniz: TODO: refactor verbose and check like in other tools (eg. esm_runscripts)
 from .cli import verbose, check
 
 from .general_stuff import (
@@ -45,19 +49,25 @@ def main_flow(parsed_args, target):
     #setups2models.replace_last_vars(env)
 
 
-    # deniz
-    import yaml
-    print(yaml.dump(complete_config, default_flow_style=False, indent=4) )
-    # deniz
-
     user_task = Task(target, setups2models, vcs, main_infos, complete_config)
+
     if verbose > 0:
         user_task.output()
 
     user_task.output_steps()
 
     if check:
+        # deniz: if the environment variable ESM_MASTER_DEBUG is also set dump
+        # the contents of the current config to stdout for more investigation 
+        if os.environ.get("ESM_MASTER_DEBUG", None):
+            print()
+            print("Contents of the complete_config:")
+            print("--------------------------------")
+            print(yaml.dump(complete_config, default_flow_style=False, indent=4) ) 
+        
+        print("esm_master: check mode is activated. Not executing the actions above")
         return 0
+    
     user_task.validate()
 
     user_task.execute() #env)

--- a/esm_master/esm_master.py
+++ b/esm_master/esm_master.py
@@ -32,12 +32,23 @@ def main_flow(parsed_args, target):
     # Miguel: Move this somewhere else after talking to Paul and Dirk
     user_config["general"]["run_or_compile"] = "compiletime"
 
+    # deniz: small bugfix: when esm_master receives --verbose, it did not make
+    # it into the configuration since it was only a global variable
+    if verbose:
+        user_config["general"]["verbose"] = True
+    
     from esm_runscripts.sim_objects import SimulationSetup
     complete_setup = SimulationSetup(user_config=user_config)
     complete_config = complete_setup.config
 
     # This will be a problem later with GEOMAR
     #setups2models.replace_last_vars(env)
+
+
+    # deniz
+    import yaml
+    print(yaml.dump(complete_config, default_flow_style=False, indent=4) )
+    # deniz
 
     user_task = Task(target, setups2models, vcs, main_infos, complete_config)
     if verbose > 0:
@@ -59,4 +70,5 @@ def main_flow(parsed_args, target):
     if not parsed_args["keep"]:
         user_task.cleanup_script()
 
+    
     return 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.6
+current_version = 5.0.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_master",
-    version="5.0.6",
+    version="5.0.7",
     zip_safe=False,
 )


### PR DESCRIPTION
I fixed a bug in the esm_master. When check is provided it did not make its way into the `user_config["general"]["verbose"]`.

Moreover, I added support for an environmental variable `ESM_MASTER_DEBUG` (as an idea from @pgierz). When it is exported prior to the execution of `esm_master` and `esm_master` is is `check` mode, the `complete_config` will be printed for further debugging.