### PR TITLE
added curl support for codes that are not hosted in repositories

### DIFF
--- a/esm_master/__init__.py
+++ b/esm_master/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.1"
+__version__ = "5.0.2"
 
 from . import database

--- a/esm_master/compile_info.py
+++ b/esm_master/compile_info.py
@@ -54,6 +54,7 @@ def combine_components_yaml():
 
     relevant_entries = [
             "git-repository",
+            "curl-repository",  # deniz
             "repo_options", # kh 11.09.20 support git options like --recursive
             "branch",
             "tag",

--- a/esm_master/general_stuff.py
+++ b/esm_master/general_stuff.py
@@ -246,6 +246,7 @@ class version_control_infos:
                 raw_command = self.config[package.repo_type][todo + "_command"]
 
 # kh 11.09.20 support git options like --recursive
+                # repo_options in the model.yaml is assigned to define_options
                 if package.repo_options:
                     define_options = self.config[package.repo_type]["define_options"]
                     raw_command = raw_command.replace("${define_options}", define_options)
@@ -284,6 +285,10 @@ class version_control_infos:
                 )
             raw_command = raw_command.replace("${repository}", repo)
             if todo == "get":
+                if package.repo_type == "curl":
+                    raw_command = raw_command.replace("${curl-repository}", repo)
+                    # return so that it is not overwritten
+                    return raw_command   
                 if package.clone_destination:
                     raw_command = raw_command + " " + package.clone_destination
                 elif package.destination:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.1
+current_version = 5.0.2
 commit = True
 tag = True
 
@@ -18,4 +18,3 @@ universal = 1
 exclude = docs
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_master",
-    version="5.0.1",
+    version="5.0.2",
     zip_safe=False,
 )


### PR DESCRIPTION
Together with the pull request in the `esm_tools`, it is now possible to download codes that are not hosted in repositories (eg. GitHub, GitLab, svn, mercurial, ...). Here is a quick example:

``` 
esm_master get-tux-1.0
esm_master comp-tux-1.0
esm_master clean-tux-1.0
```
or `esm_master install-tux-1.0`. 

Make sure that your X11 settings are on 😄 
![image](https://user-images.githubusercontent.com/51913535/110391285-8d90dc80-8067-11eb-8a43-ec2352a23e7d.png)