### PR TITLE
added support for suppressing MOTD

### DIFF
--- a/esm_master/__init__.py
+++ b/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 
 from . import database

--- a/esm_master/cli.py
+++ b/esm_master/cli.py
@@ -11,8 +11,6 @@ from . import __version__
 
 def main():
 
-    from esm_motd import check_all_esm_packages
-    check_all_esm_packages()
     # global check, verbose
 
     parser = argparse.ArgumentParser(
@@ -68,6 +66,14 @@ def main():
     )
     parser.add_argument("--generate_tab_complete", action="store_true")
     parser.add_argument("--list_all_targets", action="store_true")
+
+    parser.add_argument(
+        "--no-motd",
+        help = "supress the printing of MOTD",
+        default = False,
+        action = "store_true"
+    )
+
     parsed_args = vars(parser.parse_args())
 
     global check
@@ -77,6 +83,7 @@ def main():
     check = False
     verbose = 0
     modify_config_file = False
+    no_motd = False
 
 
     if parsed_args:
@@ -90,9 +97,17 @@ def main():
             keep = parsed_args["keep"]
         if "modify" in parsed_args: 
             modify_config_file = parsed_args["modify"]
+        if "no_motd" in parsed_args: 
+            no_motd = parsed_args["no_motd"]
 
     if not target:
         target = ""
+
+    
+    from esm_motd import check_all_esm_packages
+    
+    if not no_motd:
+        check_all_esm_packages()
 
     from .esm_master import main_flow
     main_flow(parsed_args, target)

--- a/esm_master/cli.py
+++ b/esm_master/cli.py
@@ -8,6 +8,8 @@ verbose = 0
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 from . import __version__
+from esm_motd import check_all_esm_packages
+from .esm_master import main_flow
 
 def main():
 
@@ -103,13 +105,9 @@ def main():
     if not target:
         target = ""
 
-    
-    from esm_motd import check_all_esm_packages
-    
     if not no_motd:
         check_all_esm_packages()
 
-    from .esm_master import main_flow
     main_flow(parsed_args, target)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.1.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_master",
-    version="5.1.0",
+    version="5.1.1",
     zip_safe=False,
 )


### PR DESCRIPTION
if `--no-motd` option is provided, eg. `esm_master --no-motd bla bla`, the MOTD message will not be printed. There is also another PR in the `esm_runscripts` on what @dbarbi just mentioned in today's esm_tools weekly meeting. That PR suppresses double printing of the MOTD.