### PR TITLE
bugfix for --check and refactoring the global variables

### DIFF
--- a/esm_master/__init__.py
+++ b/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 
 
 from . import database

--- a/esm_master/cli.py
+++ b/esm_master/cli.py
@@ -2,9 +2,6 @@
 import argparse
 import sys
 
-
-check = False
-verbose = 0
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 from . import __version__
@@ -12,8 +9,6 @@ from esm_motd import check_all_esm_packages
 from .esm_master import main_flow
 
 def main():
-
-    # global check, verbose
 
     parser = argparse.ArgumentParser(
         prog="esm_master",
@@ -77,9 +72,6 @@ def main():
     )
 
     parsed_args = vars(parser.parse_args())
-
-    global check
-    global verbose
 
     target = ""
     check = False

--- a/esm_master/general_stuff.py
+++ b/esm_master/general_stuff.py
@@ -1,10 +1,9 @@
+import os
+import sys
 import esm_tools
 import esm_rcfile
 import esm_parser
-import os
-import sys
 
-from .cli import verbose
 
 ######################################################################################
 ##################################### globals ########################################
@@ -131,7 +130,7 @@ def write_minimal_user_config(config):
 
 
 class GeneralInfos:
-    def __init__(self):
+    def __init__(self, parsed_args):
 
         self.config = esm_parser.yaml_file_to_dict(CONFIG_YAML)
         self.emc = self.read_and_update_conf_files()
@@ -139,7 +138,7 @@ class GeneralInfos:
         self.display_kinds = self.get_display_kinds()
 
 
-        if verbose > 1:
+        if parsed_args.get("verbose", 0):
             self.output()
 
     def read_and_update_conf_files(self):
@@ -213,7 +212,7 @@ class GeneralInfos:
 
 
 class version_control_infos:
-    def __init__(self):
+    def __init__(self, parsed_args):
         self.config = {}
         vcs_files = [f for f in os.listdir(VCS_FOLDER)]
         self.known_repos = []
@@ -235,7 +234,7 @@ class version_control_infos:
                     todo = entry.replace("_command", "")
                     if todo not in self.known_todos:
                         self.known_todos.append(todo)
-        if verbose > 1:
+        if parsed_args.get("verbose", 0):
             self.output()
 
     def assemble_command(self, package, todo, setup_info, general):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.1
+current_version = 5.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_master",
-    version="5.1.1",
+    version="5.1.2",
     zip_safe=False,
 )


### PR DESCRIPTION
This bugfix solves the issue opened by @seb-wahl : https://github.com/esm-tools/esm_master/issues/50

I had fixed a similar issue before but for some reason `--check` options fails to work again. When I debugged the code, I realized that the global variables don't go into the other sections of the code with the correct values. I wrote in the code previously that refactoring of `esm_master` to avoid the use of global variables would be idea for the future. This bugfix not only solves the issue but also refactors `esm_master`.

The bugfix passes the following tests:
- [x] `esm_master get-foci-default -c`
- [x] `esm_master get-foci-default --check`
- [x] `esm_master get-foci-default -c --verbose`
- [x] `esm_master get-foci-default --check --verbose`
- [x] `esm_master get-foci-default -c --no-motd`
- [x] `esm_master get-foci-default -c --verbose --no-motd`
- [x] `esm_master get-foci-default --check --verbose --no-motd`
