### PR TITLE
hotfix/relevant entries update with complete config

### DIFF
--- a/esm_master/__init__.py
+++ b/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.2"
+__version__ = "5.1.3"
 
 
 from . import database

--- a/esm_master/compile_info.py
+++ b/esm_master/compile_info.py
@@ -107,7 +107,7 @@ def combine_components_yaml(parsed_args):
 
     #esm_parser.pprint_config(components_dict)
     #sys.exit(0)
-    return components_dict
+    return components_dict, relevant_entries
 
 
 
@@ -333,14 +333,14 @@ class setup_and_model_infos:
     def __init__(self, vcs, general, parsed_args):
 
         if not os.path.isfile(ESM_MASTER_PICKLE):
-            self.config = combine_components_yaml(parsed_args)
+            self.config, self.relevant_entries = combine_components_yaml(parsed_args)
             save_pickle(self.config, ESM_MASTER_PICKLE)
 
         elif "list_all_packages" in parsed_args:
             self.config = load_pickle(ESM_MASTER_PICKLE)
 
         else:
-            self.config = combine_components_yaml(parsed_args)
+            self.config, self.relevant_entries = combine_components_yaml(parsed_args)
             save_pickle(self.config, ESM_MASTER_PICKLE)
 
         self.model_kinds = list(self.config.keys())
@@ -478,6 +478,15 @@ class setup_and_model_infos:
         esm_parser.recursive_run_function(
             [], self.config, "atomic", esm_parser.find_variable, self.config, [], True,
         )
+
+    def update_relevant_entries_with_config(self, config):
+        for component in config:
+            for entry in self.relevant_entries:
+                if (
+                    entry in config[component]
+                    and component in self.config["components"]
+                ):
+                    self.config["components"][component][entry] = config[component][entry]
 
     def update_packages(self, vcs, general):
         for package in self.all_packages:

--- a/esm_master/esm_master.py
+++ b/esm_master/esm_master.py
@@ -53,6 +53,8 @@ def main_flow(parsed_args, target):
     complete_setup = SimulationSetup(user_config=user_config)
     complete_config = complete_setup.config
 
+    setups2models.update_relevant_entries_with_config(complete_config)
+
     # This will be a problem later with GEOMAR
     #setups2models.replace_last_vars(env)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.2
+current_version = 5.1.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_master",
-    version="5.1.2",
+    version="5.1.3",
     zip_safe=False,
 )


### PR DESCRIPTION
This hotfix solves the following problem:

If we have a `comp_command` (or any of the `relevant_entries` for `esm_master`) that contains a variable (e.g. `archfile` in `comp_command: export XIOS_TOPLEVEL=${model_dir}; ./make_xios --arch ${archfile} --netcdf_lib netcdf4_par ${use_oasis} --job 24; cp bin/xios_server.exe bin/xios.x`), and this variable is defined in a `choose_` as for example:
```
    choose_computer.useMPI:
      cray_mpich:
        archfile: ESMTOOLS_generic_oasis_cray
      intelmpi:
        archfile: ESMTOOLS_generic_oasis_intel
```
the variable won't be resolved correctly.

This occurs because the following lines only acknowledge the existence of `choose_version`:
https://github.com/esm-tools/esm_master/blob/f5196ac4dc894122fbe45ab887178fde80bba1a6/esm_master/compile_info.py#L296-L302

In a later step, `complete_config` contains the correct `comp_command`, as it has been resolved using the parser. The solution consists on updating the `setup2models` object with the `relevant_entries` in `complete_config` to make sure that all the variables required for building are resolved correctly.